### PR TITLE
Final updates before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jest": "^28.6.0",
     "eslint-plugin-jest-formatting": "^3.1.0",
-    "eslint-plugin-lodash": "^8.0.0",
+    "eslint-plugin-lodash": "^7.4.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.32.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: ^3.1.0
     version: 3.1.0(eslint@8.57.0)
   eslint-plugin-lodash:
-    specifier: ^8.0.0
-    version: 8.0.0(eslint@8.57.0)
+    specifier: ^7.4.0
+    version: 7.4.0(eslint@8.57.0)
   eslint-plugin-no-only-tests:
     specifier: ^3.1.0
     version: 3.1.0
@@ -1382,11 +1382,11 @@ packages:
       object.fromentries: 2.0.8
     dev: false
 
-  /eslint-plugin-lodash@8.0.0(eslint@8.57.0):
-    resolution: {integrity: sha512-7DA8485FolmWRzh+8t4S8Pzin2TTuWfb0ZW3j/2fYElgk82ZanFz8vDcvc4BBPceYdX1p/za+tkbO68maDBGGw==}
+  /eslint-plugin-lodash@7.4.0(eslint@8.57.0):
+    resolution: {integrity: sha512-Tl83UwVXqe1OVeBRKUeWcfg6/pCW1GTRObbdnbEJgYwjxp5Q92MEWQaH9+dmzbRt6kvYU1Mp893E79nJiCSM8A==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: '>=9.0.0'
+      eslint: '>=2'
     dependencies:
       eslint: 8.57.0
       lodash: 4.17.21

--- a/src/universal.js
+++ b/src/universal.js
@@ -85,8 +85,18 @@ module.exports = {
 
     /* Rule overrides for "unicorn" plugin */
     'unicorn/consistent-function-scoping': 'off', // Disabling due to the rule's constraints conflicting with established patterns, especially in test suites where local helper or mocking functions are prevalent and do not necessitate exports.
+    'unicorn/import-style': [
+      'error',
+      {
+        styles: {
+          'node:path': { named: true }, // Allows import { join } from 'node:path';
+          'node:util': { default: true }, // Allows import util from 'node:util';
+        },
+      },
+    ],
     'unicorn/no-abusive-eslint-disable': 'off', // Already covered by different ruleset.
     'unicorn/no-array-callback-reference': 'error', // Explicitly turned on, because it was initially disabled and "point free" notation was enforced using "functional/prefer-tacit". That said, the point free pattern is dangerous in JS. See: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-callback-reference.md.
+    'unicorn/no-array-for-each': 'off', // We use .forEach extensively across the api3dao org and even though this can be solved with --fix and there are benefits, it will generate a lot of friction.
     'unicorn/no-array-reduce': 'off', // We are OK with using reduce occasionally, but I agree with the author that the code using reduce can easily get complex.
     'unicorn/no-nested-ternary': 'off', // This rule is smarter than the standard ESLint rule, but conflicts with prettier so it needs to be turned off. Nested ternaries are very unreadable so it's OK if all of them are flagged.
     'unicorn/no-null': 'off', // We use both null and undefined for representing three state objects. We could use a string union instead, but using combination of null and undefined is less verbose.


### PR DESCRIPTION
For the first commit, lodash 8.0.0 has eslint@>=9.0.0 as a peer dependency so I downgraded (lodash v8 also seems to haven be taken over [by an individual](https://github.com/idok/eslint-plugin-lodash) from the previous maintainer(s); I didn't look further into it)

I tested this in 2 repos:
1. `ois` - where there are a lot of lints, but most are decent and/or can be fixed with `--fix`
2. A private OEV repo that currently uses `commons/eslint` functionality (`universal` and `jest`) - I replaced the local import with this plugin and no new errors were raised besides 3 new `Unused eslint-disable directive` that result from a `@typescript-eslint` package version bump between this repo and eslint within commons.

which means after this is merged, I think we're ready for release and use.