### PR TITLE
Turn off 2 rules

### DIFF
--- a/src/jest.js
+++ b/src/jest.js
@@ -20,6 +20,7 @@ module.exports = {
       rules: {
         'jest/prefer-expect-assertions': 'off', // While useful, enforcing this can lead to verbose tests.
         'jest/prefer-each': 'off', // We find traditional for-loops more readable in certain contexts.
+        'jest/prefer-importing-jest-globals': 'off', // This would be very bothersome for existing repos.
         'jest/require-top-level-describe': 'off', // Multiple top-level describe blocks or tests can be acceptable.
         'jest/max-expects': 'off', // Limiting expect statements is beneficial, but enforcing a strict count can be restrictive.
         'jest/valid-title': 'off', // This restriction can prevent using titles like "<function-name>.name".

--- a/src/jest.js
+++ b/src/jest.js
@@ -18,19 +18,19 @@ module.exports = {
       plugins: ['jest'],
       extends: ['plugin:jest/recommended', 'plugin:jest-formatting/recommended'],
       rules: {
-        'jest/prefer-expect-assertions': 'off', // While useful, enforcing this can lead to verbose tests.
-        'jest/prefer-each': 'off', // We find traditional for-loops more readable in certain contexts.
-        'jest/prefer-importing-jest-globals': 'off', // This would be very bothersome for existing repos.
-        'jest/require-top-level-describe': 'off', // Multiple top-level describe blocks or tests can be acceptable.
         'jest/max-expects': 'off', // Limiting expect statements is beneficial, but enforcing a strict count can be restrictive.
-        'jest/valid-title': 'off', // This restriction can prevent using titles like "<function-name>.name".
         'jest/no-hooks': [
           'error', // We advocate for setup functions over beforeXXX hooks. However, afterXyz hooks are sometimes indispensable, like for resetting Jest timers. See: https://kentcdodds.com/blog/avoid-nesting-when-youre-testing#inline-it.
           {
             allow: ['afterEach', 'afterAll'],
           },
         ],
-        'prefer-lowercase-title': 'off', // Sometimes we want to start the test with a capital letter and some words are all uppercase (e.g. AWS).
+        'jest/prefer-each': 'off', // We find traditional for-loops more readable in certain contexts.
+        'jest/prefer-expect-assertions': 'off', // While useful, enforcing this can lead to verbose tests.
+        'jest/prefer-importing-jest-globals': 'off', // This would be very bothersome for existing repos.
+        'jest/require-top-level-describe': 'off', // Multiple top-level describe blocks or tests can be acceptable.
+        'jest/valid-title': 'off', // This restriction can prevent using titles like "<function-name>.name".
+        'prefer-lowercase-title': 'off', // Sometimes we want to start the test with a capital letter and some words are all uppercase (e.g. AWS).,
       },
     },
   ],

--- a/src/universal.js
+++ b/src/universal.js
@@ -103,6 +103,7 @@ module.exports = {
     'unicorn/no-object-as-default-parameter': 'off', // Too restrictive. TypeScript can ensure that the default value matches the type.
     'unicorn/no-useless-undefined': ['error', { checkArguments: false }], // We need to disable "checkArguments", because if a function expects a value of type "T | undefined" the undefined value needs to be passed explicitly.
     'unicorn/prefer-module': 'off', // We use CJS for configuration files and tests. There is no rush to migrate to ESM and the configuration files are probably not yet ready for ESM yet.
+    'unicorn/prefer-string-raw': 'off', // We commonly escape \ in strings.
     'unicorn/prevent-abbreviations': 'off', // This rule reports many false positives and leads to more verbose code.
 
     /* Rule overrides for "import" plugin */


### PR DESCRIPTION
Closes #10 by turning off the two rules discussed. The jest rules are alphabetically sorted in the second commit.