### PR TITLE
ci: ignore node in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
   "extends": ["config:base"],
   "packageRules": [
     {
+      "matchPackageNames": ["node"],
+      "enabled": false
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 4am on Monday"],


### PR DESCRIPTION
Will avoid renovate frequently opening PRs e.g. #21 and #22