### PR TITLE
Remove rule @shopify/no-ancestor-directory-import

### DIFF
--- a/src/universal.js
+++ b/src/universal.js
@@ -210,7 +210,6 @@ module.exports = {
     /* Select rules from Shopify */
     '@shopify/prefer-early-return': 'error',
     '@shopify/prefer-module-scope-constants': 'error',
-    '@shopify/no-ancestor-directory-import': 'error',
   },
   overrides: [
     // Overrides for Jest tests.


### PR DESCRIPTION
Removing newly introduced rule that causes annoyance in several repos as discussed [here](https://github.com/api3dao/commons/pull/109#issuecomment-2249743890)