### PR TITLE
Turn off functional/no-promise-reject

### DIFF
--- a/src/universal.js
+++ b/src/universal.js
@@ -191,7 +191,7 @@ module.exports = {
 
     /* Rule overrides for "functional" plugin */
     'functional/no-classes': 'error', // Functions are all we need.
-    'functional/no-promise-reject': 'error',
+    'functional/no-promise-reject': 'off', // Expanded scope of the rule is too restrictive against using throw
     'functional/no-try-statements': 'error', // Use go utils instead.
     'functional/prefer-tacit': 'off', // The rule is dangerous. See: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-callback-reference.md.
 


### PR DESCRIPTION
In the [6.6.2 patch bump](https://github.com/eslint-functional/eslint-plugin-functional/blob/v6.6.3/CHANGELOG.md#bug-fixes-1) (grr) eslint-plugin-functional expanded the scope of no-promise-reject to now flag a number of instances in `commons`, for example:
- https://github.com/api3dao/commons/blob/b095a8f9f6b3fa510fbdd6f0d9cc377d350eeb2a/src/processing/processing.ts#L106
- https://github.com/api3dao/commons/blob/b095a8f9f6b3fa510fbdd6f0d9cc377d350eeb2a/src/processing/processing.ts#L168
- https://github.com/api3dao/commons/blob/b095a8f9f6b3fa510fbdd6f0d9cc377d350eeb2a/src/processing/processing.ts#L200
- https://github.com/api3dao/commons/blob/b095a8f9f6b3fa510fbdd6f0d9cc377d350eeb2a/src/processing/processing.ts#L243

so I suggest turning off.